### PR TITLE
Yaml and multi instrument fix

### DIFF
--- a/pahfit/PAHFIT_Spitzer_Exgal.py
+++ b/pahfit/PAHFIT_Spitzer_Exgal.py
@@ -80,7 +80,7 @@ class SciPackExGal:
         # rest for for the dust emission
         bb_temps = [5000.0, 300.0, 200.0, 135.0, 90.0, 65.0, 50.0, 40.0, 35.0]
         n_bb = len(bb_temps)
-        bb_names = ["StellarBB"] + ["ContMBB{}".format(k) for k in range(n_bb - 1)]
+        bb_names = ["starlight"] + [f"dust_cont{k:02}" for k in range(n_bb - 1)]
         bb_amps = np.full(n_bb, 1.0e-10)
         self.bb_info = {
             "names": bb_names,

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -843,7 +843,7 @@ class PAHFITBase:
             feature_dict.update(
                 {
                     "fwhms": values,
-                    "fwhms_fixed": fixed.tolist(),
+                    "fwhms_fixed": fixed,
                     "fwhms_limits": list(zip(mins, maxes)),
                 }
             )

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import matplotlib as mpl
 
-from pahfit.instrument import wave_range, fwhm
+from pahfit.instrument import test_waves_in_any_segment, fwhm_recommendation
 from pahfit.feature_strengths import (
     pah_feature_strength,
     line_strength,
@@ -813,33 +813,40 @@ class PAHFITBase:
         updated feature_dict
         """
 
-        wave_instrument = wave_range(instrumentname)
-        ind = np.where((feature_dict['x_0'] > wave_instrument[0])
-                       & (feature_dict['x_0'] < wave_instrument[1]))
+        ind = np.nonzero(
+            test_waves_in_any_segment(feature_dict["x_0"], instrumentname)
+        )[0]
 
-        feature_dict.update({'x_0': feature_dict['x_0'][ind]})
-        feature_dict.update({'amps': feature_dict['amps'][ind]})
-        feature_dict.update({'fwhms': feature_dict['fwhms'][ind]})
-        feature_dict.update({'names': feature_dict['names'][ind]})
-        feature_dict.update(
-            {'amps_fixed': np.array(feature_dict['amps_fixed'])[ind].tolist()})
-        feature_dict.update({
-            'fwhms_fixed':
-            np.array(feature_dict['fwhms_fixed'])[ind].tolist()
-        })
-        feature_dict.update(
-            {'x_0_fixed': np.array(feature_dict['x_0_fixed'])[ind].tolist()})
-        feature_dict.update(
-            {'x_0_limits': np.array(feature_dict['x_0_limits'])[ind]})
-        feature_dict.update(
-            {'amps_limits': np.array(feature_dict['amps_limits'])[ind]})
-        feature_dict.update(
-            {'fwhms_limits': np.array(feature_dict['fwhms_limits'])[ind]})
+        # select the valid entries in these arrays
+        array_keys = ("x_0", "amps", "fwhms", "names")
+        new_values_1 = {key: feature_dict[key][ind] for key in array_keys}
+
+        # these are lists instead
+        list_keys = (
+            "amps_fixed",
+            "fwhms_fixed",
+            "x_0_fixed",
+            "x_0_limits",
+            "amps_limits",
+            "fwhms_limits",
+        )
+        new_values_2 = {
+            key: [feature_dict[key][i] for i in ind] for key in list_keys
+        }
+
+        feature_dict.update(new_values_1)
+        feature_dict.update(new_values_2)
 
         if update_fwhms:
-            x_0_val = feature_dict['x_0']
-            fwhm_val = fwhm(instrumentname, x_0_val)
-            feature_dict.update({'fwhms': fwhm_val})
+            waves = feature_dict["x_0"]
+            values, fixed, mins, maxes = fwhm_recommendation(instrumentname, waves)
+            feature_dict.update(
+                {
+                    "fwhms": values,
+                    "fwhms_fixed": fixed.tolist(),
+                    "fwhms_limits": list(zip(mins, maxes)),
+                }
+            )
 
         return feature_dict
 

--- a/pahfit/helpers.py
+++ b/pahfit/helpers.py
@@ -136,6 +136,7 @@ def initialize_model(packfile, instrumentname, obsdata, estimate_start=False):
     pmodel = PAHFITBase(
         obsdata["x"].value,
         obsdata["y"].value,
+        instrumentname,
         estimate_start=estimate_start,
         filename=packfile_found,
     )

--- a/pahfit/helpers.py
+++ b/pahfit/helpers.py
@@ -9,7 +9,7 @@ from astropy.table import Table
 from astropy.modeling.fitting import LevMarLSQFitter
 
 from pahfit.base import PAHFITBase
-from pahfit.instrument import wave_range
+from pahfit.instrument import test_wave_minmax
 from pahfit.features import Features
 
 from pahfit.component_models import BlackBody1D, S07_attenuation
@@ -124,13 +124,10 @@ def initialize_model(packfile, instrumentname, obsdata, estimate_start=False):
     """
 
     packfile_found = find_packfile(packfile)
-    wave_min = min(obsdata["x"].value)
-    wave_max = max(obsdata["x"].value)
 
-    wave_instrument = wave_range(instrumentname)
-    if wave_min < wave_instrument[0] or wave_max > wave_instrument[1]:
+    if not test_wave_minmax(obsdata["x"].value, instrumentname):
         raise ValueError(
-            'Wavelength range of the input spectrum and the instrument do not match'
+            "Wavelength range of the input spectrum and the instrument do not match"
         )
 
     pmodel = PAHFITBase(

--- a/pahfit/instrument.py
+++ b/pahfit/instrument.py
@@ -192,4 +192,28 @@ def wave_range(segment):
         return ret
 
 
+def test_wave_range(wave_micron, segments):
+    """Return True if the instrument range encompasses the given wavelengths
+
+    For now, it is just based on the mininum and maximum, but it could
+    check all the wavelengths in the future, to make sure that all
+    observational data is covered by a valid instrument model.
+
+    Parameters
+    ----------
+    wave_micron: 1D array-like (not quantity)
+        list of wavelengths in micron
+
+    segments: list of str
+        list of instrument segment names, as defined by the pack_element function
+
+    """
+    ranges = [x["range"] for x in pack_element(segments)]
+    wmin = min(wave_micron)
+    wmax = max(wave_micron)
+    rmin = min(r[0] for r in ranges)
+    rmax = max(r[1] for r in ranges)
+    return rmin <= wmin and wmax <= rmax
+
+
 read_instrument_packs()

--- a/pahfit/instrument.py
+++ b/pahfit/instrument.py
@@ -201,9 +201,13 @@ def fwhm_recommendation(segment, wave_micron):
     """Returns recommended parameters for the fwhm.
 
     This function checks the shape of the output of fhwm(), and returns consistent values.
-    - Value as a starting point
-    - Min and max where there is segment overlap, masked where there is no overlap
-    - 'fixed' flag, False where there is overlap
+    - value as a starting point
+    - upper and lower, or masked where there is no overlap
+    - 'fixed' flag
+
+    When a wavelength is covered by only one segment, the recommendation
+    is to fix the fwhm. In case of multiple, it should be variable,
+    between the given upper and lower bounds.
 
     Parameters
     ----------
@@ -224,10 +228,10 @@ def fwhm_recommendation(segment, wave_micron):
     if len(fwhm_output.shape) == 1:
         return fwhm_output, [True] * N, [0.] * N, [0.] * N
     else:
-        # when a wavelength is covered by only one segment, the
-        # recommendation is to fix the fwhm. In case of multiple, it
-        # should be variable, between the given upper and lower bounds
-        fixed = list(fwhm_output[: , 1].mask)
+        # We need to be careful here, because for astropy a numpy.bool
+        # does not work for the 'fixed' parameter. It needs to be a
+        # regular bool. Tolist() solves this.
+        fixed = fwhm_output[: , 1].mask.tolist()
         return fwhm_output[:, 0], fixed, fwhm_output[:, 1], fwhm_output[:, 2]
 
 

--- a/pahfit/instrument.py
+++ b/pahfit/instrument.py
@@ -29,12 +29,13 @@ def read_instrument_packs():
             with open(pack) as fd:
                 p = yaml.load(fd)
         except IOError as e:
-            raise PAHFITPackError("Error reading instrument pack file\n"
-                                  f"\t{pack}\n\t{repr(e)}")
+            raise PAHFITPackError(
+                "Error reading instrument pack file\n" f"\t{pack}\n\t{repr(e)}"
+            )
         else:
-            telescope = os.path.basename(pack).rstrip('.yaml')
+            telescope = os.path.basename(pack).rstrip(".yaml")
             packs[telescope] = p
-    packs = dict(_ins_items('', packs))  # Flatten list
+    packs = dict(_ins_items("", packs))  # Flatten list
 
 
 def pack_element(segments):
@@ -72,9 +73,9 @@ def pack_element(segments):
         if not sm:
             raise PAHFITPackError(f"Could not locate instrument segment {segment}")
         for s in sm:
-            if packs[s].get('polynomial') is None:
+            if packs[s].get("polynomial") is None:
                 try:
-                    packs[s]['polynomial'] = Polynomial(packs[s]['coefficients'])
+                    packs[s]["polynomial"] = Polynomial(packs[s]["coefficients"])
                 except KeyError:
                     raise PAHFITPackError(f"Invalid instrument pack {s}")
             ret.append(packs[s])
@@ -128,14 +129,14 @@ def resolution(segment, wave_micron):
     _packs = pack_element(segment)
     npk = len(_packs)
     if npk == 1:
-        return _packs[0]['polynomial'](wave_micron)
+        return _packs[0]["polynomial"](wave_micron)
 
     wave_micron = np.atleast_1d(wave_micron)
 
     res = np.ma.empty((npk,) + wave_micron.shape)
     for i, p in enumerate(_packs):
-        inside = (wave_micron >= p['range'][0]) & (wave_micron <= p['range'][1])
-        res[i, inside] = p['polynomial'](wave_micron[inside])
+        inside = (wave_micron >= p["range"][0]) & (wave_micron <= p["range"][1])
+        res[i, inside] = p["polynomial"](wave_micron[inside])
         res[i, ~inside] = np.ma.masked
 
     out = np.ma.empty_like(wave_micron, shape=wave_micron.shape + (3,))
@@ -185,7 +186,7 @@ def wave_range(segment):
     matching), the return value is a list of two element lists [min,
     max].
     """
-    ret = [x['range'] for x in pack_element(segment)]
+    ret = [x["range"] for x in pack_element(segment)]
     if len(ret) == 1:
         return ret[0]
     else:

--- a/pahfit/instrument.py
+++ b/pahfit/instrument.py
@@ -215,7 +215,7 @@ def fwhm_recommendation(segment, wave_micron):
     Returns
     -------
     Tuple of lists / arrays. Each one of size len(wave_micron)
-        (float, bool, float, float)
+        (array float, list bool, array float, array float)
         (fwhm, bool fixed, low bound, high bound)
 
     """
@@ -227,7 +227,7 @@ def fwhm_recommendation(segment, wave_micron):
         # when a wavelength is covered by only one segment, the
         # recommendation is to fix the fwhm. In case of multiple, it
         # should be variable, between the given upper and lower bounds
-        fixed = fwhm_output[: , 1].mask
+        fixed = list(fwhm_output[: , 1].mask)
         return fwhm_output[:, 0], fixed, fwhm_output[:, 1], fwhm_output[:, 2]
 
 

--- a/pahfit/packs/instrument.py
+++ b/pahfit/packs/instrument.py
@@ -9,8 +9,10 @@ heirarchical names, e.g. 'iso.sws.speed0.3a'.  For the full list of
 supported telescopes, instruments, and instrument modes, see TBD.
 """
 
-import glob
 import os
+from pathlib import Path
+import glob
+import numpy as np
 from numpy.polynomial import Polynomial
 from astropy.io.misc import yaml
 from pkg_resources import resource_filename
@@ -21,6 +23,7 @@ packs = {}
 
 def read_instrument_packs():
     """Read all instrument packs into the 'packs' variable."""
+    global packs
     for pack in glob.glob(resource_filename("pahfit", "packs/instrument/*.yaml")):
         try:
             with open(pack) as fd:
@@ -31,61 +34,120 @@ def read_instrument_packs():
         else:
             telescope = os.path.basename(pack).rstrip('.yaml')
             packs[telescope] = p
+    packs = dict(_ins_items('', packs))  # Flatten list
 
 
-def pack_element(segment):
-    """Return the pack element for the given segment name.
+def pack_element(segments):
+    """Return the pack element(s) for the given segment name(s).
 
     Arguments:
     ----------
-      segment: The fully qualified segment name, as a string.
+
+      segments: The fully qualified segment name, as a string. Can be a
+        scalar or a list, for returning more than one pack.  Each
+        segment name can optionally contain glob characters recognized
+        by Pathlib.Path.match (e.g. `*' or [123]).  This can be used
+        to match multiple segments.
 
     Returns:
     --------
 
-    The dictionary structure including the keys 'range' and
-    'coefficients' of the named segment.
+    A list of dictionary structures including the keys 'range' and
+    'coefficients' of the named segment(s).
 
     Raises:
     -------
 
-    PAHFITPackError: If the named segment cannot be identified.
+    PAHFITPackError: If none of the named segments can be identified.
+
     """
     global packs
-    d = packs
-    for key in segment.split('.'):
-        d = d.get(key)
-        if d is None:
-            raise PAHFITPackError(f"Could not locate instrument segment {key} of {segment}")
-    if d.get('polynomial') is None:
-        try:
-            d['polynomial'] = Polynomial(d['coefficients'])
-        except KeyError:
-            raise PAHFITPackError(f"Incomplete segment name {segment}")
+    ret = []
 
-    return d
+    if not isinstance(segments, (tuple, list)):
+        segments = (segments,)
+
+    for segment in segments:
+        sm = [p for p in packs.keys() if Path(p).match(segment)]
+        if not sm:
+            raise PAHFITPackError(f"Could not locate instrument segment {segment}")
+        for s in sm:
+            if packs[s].get('polynomial') is None:
+                try:
+                    packs[s]['polynomial'] = Polynomial(packs[s]['coefficients'])
+                except KeyError:
+                    raise PAHFITPackError(f"Invalid instrument pack {s}")
+            ret.append(packs[s])
+
+    return ret
 
 
-def _ins_name(path, tree):
-    """Generator for instrument names."""
+def _ins_items(path, tree):
+    """Generator for traversing packs."""
     if isinstance(tree, dict) and not tree.get("range"):
         _dot = "." if len(path) > 0 else ""
         for key, sub in tree.items():
-            yield from _ins_name(f"{path}{_dot}{key}", sub)
+            yield from _ins_items(f"{path}{_dot}{key}", sub)
     else:
-        yield path
+        yield path, tree
 
 
-def instruments():
-    """Returns fully qualified set of supported instrument names."""
+def instruments(match=None):
+    """Returns fully qualified set of supported instrument names.
+
+    Arguments:
+    ----------
+
+      match (Optional): A string or iterable of strings to match
+       against the full instrument list. If provide, only the list of
+       matching instruments is returned.  Useful for checking a
+       glob-style instrument name results in the desired instrument
+       set.
+
+    Returns:
+    --------
+
+      The list of matching instruments, if any.
+
+    """
     if len(packs) == 0:
         read_instrument_packs()
-    return _ins_name('', packs)
+    ins = packs.keys()
+    ret = []
+    if match:
+        if not isinstance(match, (tuple, list)):
+            match = (match,)
+        for m in match:
+            ret.extend([p for p in ins if Path(p).match(m)])
+        return ret
+    else:
+        return list(ins)
 
 
 def resolution(segment, wave_micron):
-    p = pack_element(segment)['polynomial']
-    return p(wave_micron)
+    _packs = pack_element(segment)
+    npk = len(_packs)
+    if npk == 1:
+        return _packs[0]['polynomial'](wave_micron)
+
+    wave_micron = np.atleast_1d(wave_micron)
+
+    res = np.ma.empty((npk,) + wave_micron.shape)
+    for i, p in enumerate(_packs):
+        inside = (wave_micron >= p['range'][0]) & (wave_micron <= p['range'][1])
+        res[i, inside] = p['polynomial'](wave_micron[inside])
+        res[i, ~inside] = np.ma.masked
+
+    out = np.ma.empty_like(wave_micron, shape=wave_micron.shape + (3,))
+    out[:] = np.ma.masked  # mask all by default
+    out[..., 0] = np.mean(res, 0)
+
+    multi = np.count_nonzero(res, 0) > 1  # waves matching more than one segment
+    if np.count_nonzero(multi) > 0:
+        out[multi, 1] = np.min(res[:, multi], 0)
+        out[multi, 2] = np.max(res[:, multi], 0)
+
+    return out
 
 
 def fwhm(segment, wave_micron):
@@ -96,20 +158,38 @@ def fwhm(segment, wave_micron):
       segment: The fully qualified segment name, as a string.
 
       wave_micron: The observed-frame (instrument-relative) wavelength
-      in microns, as a scalar or numpy array.
+        in microns, as a scalar or numpy array.
 
     Returns:
     --------
 
-    The full-width at half maximum of an unresolved line spread
-    function, at the relevant wavelength(s).
+    The full-width at half maxima of unresolved line spread functions
+    at the relevant wavelength(s), either as a scalar (if only one
+    segment applied) or as a 3 element tuple of:
+
+      (value, low bound, high bound)
+
     """
-    return wave_micron / resolution(segment, wave_micron)
+
+    r = resolution(segment, wave_micron)
+    if np.ma.isMaskedArray(r):
+        ret = np.expand_dims(wave_micron, -1) / r
+        return ret[..., (0, 2, 1)]  # swap lower with upper (inverse!)
+    else:
+        return wave_micron / r
 
 
 def wave_range(segment):
-    """Return the segment wavelength range (a two element list) in microns."""
-    return pack_element(segment)['range']
+    """Return the segment wavelength range(s) in microns.  If more
+    than one segment is specified (either directly, or via glob-style
+    matching), the return value is a list of two element lists [min,
+    max].
+    """
+    ret = [x['range'] for x in pack_element(segment)]
+    if len(ret) == 1:
+        return ret[0]
+    else:
+        return ret
 
 
 read_instrument_packs()

--- a/pahfit/packs/instrument/spitzer.yaml
+++ b/pahfit/packs/instrument/spitzer.yaml
@@ -32,10 +32,10 @@ irs:
             coefficients: [0.0, 8.2667]
     ll:
         '1':
-            range: [19.4, 21.65]
+            range: [20.5, 38.5]
             coefficients: [0.0, 2.9524]
         '2':
-            range: [14.2, 21.1]
+            range: [14.5, 21.1]
             coefficients: [0.0, 5.9048]
         '3':
             range: [19.4, 21.65]

--- a/pahfit/tests/test_feature_parsing.py
+++ b/pahfit/tests/test_feature_parsing.py
@@ -2,9 +2,10 @@ from astropy.table import Table
 import numpy as np
 from pahfit.base import PAHFITBase
 from pahfit.helpers import find_packfile
+from pahfit.features import Features
 
 
-def test_model_trimming():
+def test_feature_parsing():
     """
     Goal
     ----
@@ -22,7 +23,7 @@ def test_model_trimming():
     features, ...) can deal with those feature not being there.
 
     """
-    # fake obsdata from 0 to 30 micron (will not actually do fitting in
+    # fake obsdata from 1 to 30 micron (will not actually do fitting in
     # this test)
     N = 100
     obsdata = {
@@ -32,14 +33,15 @@ def test_model_trimming():
     }
 
     # choose any science pack
-    packfile = find_packfile("scipack_ExGal_SpitzerIRSSLLL.ipac")
+    packfile = find_packfile("classic.yaml")
 
-    # load the pack table using astropy
-    packtable = Table.read(packfile, format=packfile.split(".")[-1])
+    # convert the yaml prescription to a features table
+    features = Features.read(packfile)
 
-    # parse table into the param_info dict, and init PAHFITBase object from it
-    def parse_and_init(astropy_table):
-        param_info = PAHFITBase.parse_table(astropy_table)
+    # parse features table into the param_info dict, and init PAHFITBase
+    # object from it
+    def parse_and_init(features_instance):
+        param_info = PAHFITBase.parse_table(features_instance)
         pmodel = PAHFITBase(
             obsdata["x"], obsdata["y"], estimate_start=True, param_info=param_info
         )
@@ -47,13 +49,13 @@ def test_model_trimming():
 
     # Case 0: the whole table
     # whole_pmodel
-    _ = parse_and_init(packtable)
+    _ = parse_and_init(features)
 
     # Case 1, 2, and 3 (no BB, Gauss, Drude)
     remove_forms = ["BlackBody1D", "Gaussian1D", "Drude1D", "att_Drude1D"]
     for form in remove_forms:
-        _ = parse_and_init(packtable[packtable["Form"] != form])
+        _ = parse_and_init(features[features["Form"] != form])
 
 
 if __name__ == "__main__":
-    test_model_trimming()
+    test_feature_parsing()

--- a/pahfit/tests/test_fitting_spitzer.py
+++ b/pahfit/tests/test_fitting_spitzer.py
@@ -5,13 +5,16 @@ from pahfit.helpers import read_spectrum, initialize_model, fit_spectrum
 
 def test_fitting_m101():
 
-    # read in the spectrum
+    # read in the spectrum (goes from 5.257 to 38.299)
     spectrumfile = "M101_Nucleus_irs.ipac"
     obsdata = read_spectrum(spectrumfile)
 
-    # setup the model
-    packfile = "scipack_ExGal_SpitzerIRSSLLL.ipac"
-    pmodel = initialize_model(packfile, obsdata, estimate_start=True)
+    # Setup the model. Keep the old pack as a comment for later reference.
+    # packfile = "scipack_ExGal_SpitzerIRSSLLL.ipac"
+    packfile = "classic.yaml"
+    # use a spitzer instrument model that covers the required range. SL1, SL2, LL1, LL2 should do
+    instrumentname = [f"spitzer.irs.{mode}" for mode in ('sl.2', 'sl.2', 'll.2', 'll.1')]
+    pmodel = initialize_model(packfile, instrumentname, obsdata, estimate_start=True)
 
     # fit the spectrum
     obsfit = fit_spectrum(obsdata, pmodel, maxiter=1000)


### PR DESCRIPTION
First, I fixed my test for parse_table. It has been renamed to feature_parsing_test. It is simply a test that checks for crashes. The results are not actually checked for now.

Then, I specified the classic pack in the other tests. I merged in this code https://github.com/PAHFIT/pahfit/pull/229, so that I could set up an instrument model with the appropriate wavelength range for the test data.

Then, I had to make changes to the `instrument` and `base` code to put it all together, dealing with the multi-segment instrument models in different places. In the process of figuring out how the multi-segment instrument code works, I added some docstrings too.

Important changes perhaps: for lines that fall in segment overlap regions (as flagged by `instrument.resolution()`), the FWHM is made flexible, and the bounds returned by `instrument.fwhm()` are used. For the lines that belong to just a single segment, fixed is set to True. This is done in a new function `instrument.fwhm_recommendation()`. I adjusted `PAHFITBase.update_dict` as necessary to make use of this.

If you merge these changes, they should appear in your pull request (with the authors of the commits preserved). The tests don't succeed yet, but we're getting closer. The current state is that the tests run without crashing, but then the assertions at the end show differences as expected.
